### PR TITLE
have run_tests script search for executable more aggressively

### DIFF
--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -25,15 +25,20 @@ EOF
 readonly script_directory=$(dirname "$0")
 cd "$script_directory"
 
-if [ -f '../build/perceptualdiff' ]
-then
-	pdiff=../build/perceptualdiff
-elif [ -f '../perceptualdiff' ]
-then
-	pdiff=../perceptualdiff
+found=0
+for d in ../build .. ../obj*; do
+    pdiff="$d/perceptualdiff"
+    if [ -f "$pdiff" ]; then
+	found=1
+	break
+    fi
+done
+
+if [ $found = 0 ]; then
+    echo 'perceptualdiff must be built and exist in the repository root or the "build" directory'
+    exit 1
 else
-	echo 'perceptualdiff must be built and exist in the repository root or the "build" directory'
-	exit 1
+    echo "*** testing executable binary $pdiff"
 fi
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
In monkeying with the debian packaging the automatic testing facilities threw an error because the executable was at obj-x86_64-linux-gnu/perceptualdiff but it is easy to make the script search a bit more thoroughly.