### PR TITLE
Libdispatch support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
 project(perceptualdiff)
 
-cmake_minimum_required(VERSION 2.4)
+cmake_minimum_required(VERSION 2.8.7)
 
 add_executable(
   perceptualdiff
-  perceptualdiff.cpp lpyramid.cpp rgba_image.cpp compare_args.cpp metric.cpp)
+  perceptualdiff.cpp lpyramid.cpp rgba_image.cpp compare_args.cpp metric.cpp dispatch_wrapper.cpp)
 
 install(TARGETS perceptualdiff DESTINATION bin)
 
@@ -15,25 +15,15 @@ find_package(FreeImage)
 include_directories(SYSTEM ${FREEIMAGE_INCLUDE_DIRS})
 target_link_libraries(perceptualdiff ${FREEIMAGE_LIBRARIES})
 
-set(CMAKE_BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE Release CACHE STRING "set build type to release")
 
-find_package(OpenMP)
-if(OPENMP_FOUND)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-endif()
-
-option(OPTIMIZATION "Enable optimization" TRUE)
-if(OPTIMIZATION)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O0")
-endif()
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -flto -Wall")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O0 -Wall")
 
 if(MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wall -Wextra -pedantic -Wcast-qual -Wpointer-arith -Winit-self -Wswitch-default -Wmissing-include-dirs -Wold-style-cast -Wnon-virtual-dtor -Wshadow -Wno-unknown-pragmas")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -Wextra -pedantic -Wcast-qual -Wpointer-arith -Winit-self -Wswitch-default -Wmissing-include-dirs -Wold-style-cast -Wnon-virtual-dtor -Wshadow -Wno-unknown-pragmas")
 endif(MSVC)
 
 # Packing stuff.

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,9 @@ Build Instructions
     - On OS X with MacPorts: ``port install freeimage``
     - On OS X with Brew: ``brew install freeimage``
     - On Ubuntu: ``apt-get install libfreeimage-dev``
+#. Download libdispatch from http://libdispatch.macosforge.org.
+    - On OS X just install Xcode and it's done
+    - On Ubuntu: ``apt-get install libdispatch-dev``
 #. Type::
 
     $ cmake .
@@ -72,12 +75,6 @@ Command line::
       --scale          Scale images to match each other's dimensions
       --sum-errors     Print a sum of the luminance and color differences
       --output o       Write difference to the file o
-
-
-Check that perceptualdiff is built with OpenMP support::
-
-    $ ./perceptualdiff | grep -i openmp
-    OpenMP status: enabled
 
 
 Credits

--- a/compare_args.cpp
+++ b/compare_args.cpp
@@ -94,13 +94,7 @@ CompareArgs::CompareArgs()
 static void print_help()
 {
     std::cout << USAGE;
-    std::cout << "\n"
-       << "OpenMP status: ";
-#ifdef _OPENMP
-    std::cout << "enabled\n";
-#else
-    std::cout << "disabled\n";
-#endif
+    std::cout << std::endl;
 }
 
 bool CompareArgs::parse_args(const int argc, char **argv)

--- a/dispatch_wrapper.cpp
+++ b/dispatch_wrapper.cpp
@@ -1,0 +1,38 @@
+#include "dispatch_wrapper.h"
+
+static void helper_void_size_t(void *context, size_t idx)
+{
+    const std::function<void(size_t)> &func = *(std::function<void(size_t)> *)context;
+
+    func(idx);
+}
+
+static void helper_void_void(void *context)
+{
+    const std::function<void(void)> &func = *(std::function<void(void)> *)context;
+
+    func();
+}
+
+namespace dispatch
+{
+    void dispatch_async(dispatch_queue_t queue, const std::function<void(void)> &func)
+    {
+        dispatch_async_f(queue, (void *)&func, helper_void_void);
+    }
+
+    void dispatch_sync(dispatch_queue_t queue, const std::function<void(void)> &func)
+    {
+        dispatch_sync_f(queue, (void *)&func, helper_void_void);
+    }
+
+    void dispatch_apply(size_t iterations, dispatch_queue_t queue, const std::function<void(size_t)> &func)
+    {
+        dispatch_apply_f(iterations, queue, (void *)&func, helper_void_size_t);
+    }
+
+    void dispatch_group_async(dispatch_group_t group, dispatch_queue_t queue, const std::function<void(void)> &func)
+    {
+        dispatch_group_async_f(group, queue, (void *)&func, helper_void_void);
+    }
+};

--- a/dispatch_wrapper.h
+++ b/dispatch_wrapper.h
@@ -1,0 +1,15 @@
+#include <dispatch/dispatch.h>
+#include <functional>
+#include <mutex>
+
+namespace dispatch
+{
+    void dispatch_async(dispatch_queue_t queue, const std::function<void(void)> &func);
+    void dispatch_sync(dispatch_queue_t queue, const std::function<void(void)> &func);
+
+    void dispatch_set_finalizer(dispatch_queue_t queue, const std::function<void(void *)> &func);
+
+    void dispatch_apply(size_t iterations, dispatch_queue_t queue, const std::function<void(size_t)> &func);
+
+    void dispatch_group_async(dispatch_group_t group, dispatch_queue_t queue, const std::function<void(void)> &func);
+};

--- a/lpyramid.cpp
+++ b/lpyramid.cpp
@@ -18,6 +18,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
 #include "lpyramid.h"
+#include "dispatch_wrapper.h"
 
 #include <algorithm>
 #include <cassert>
@@ -52,9 +53,7 @@ void LPyramid::convolve(std::vector<float> &a,
     assert(a.size() > 1);
     assert(b.size() > 1);
 
-    #pragma omp parallel for shared(a, b)
-    for (auto y = 0; y < static_cast<ptrdiff_t>(weight_); y++)
-    {
+    dispatch::dispatch_apply(static_cast<ptrdiff_t>(weight_), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), [&] (size_t y) {
         for (auto x = 0u; x < width_; x++)
         {
             const auto index = y * width_ + x;
@@ -84,7 +83,7 @@ void LPyramid::convolve(std::vector<float> &a,
             }
             a[index] = result;
         }
-    }
+    });
 }
 
 float LPyramid::get_value(const unsigned int x, const unsigned int y,

--- a/metric.cpp
+++ b/metric.cpp
@@ -392,8 +392,10 @@ bool yee_compare(CompareArgs &args)
                 }
             }
 
-            dispatch::dispatch_sync(queue, [pri_error_sum, &error_sum] () { error_sum += pri_error_sum; });
-            dispatch::dispatch_sync(queue, [&] () { pixels_failed += pri_pixels_failed; });
+            dispatch::dispatch_sync(queue, [&] () {
+                error_sum += pri_error_sum;
+                pixels_failed += pri_pixels_failed;
+            });
         }
     });
 

--- a/metric.cpp
+++ b/metric.cpp
@@ -304,7 +304,7 @@ bool yee_compare(CompareArgs &args)
     auto pixels_failed = 0u;
     auto error_sum = 0.;
 
-    dispatch_queue_t queue = dispatch_queue_create("", DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_t queue = dispatch_queue_create("perceptualdiff.yee_compare", DISPATCH_QUEUE_SERIAL);
 
     const ptrdiff_t stride = 60;
 

--- a/metric.cpp
+++ b/metric.cpp
@@ -309,7 +309,7 @@ bool yee_compare(CompareArgs &args)
     const ptrdiff_t stride = 60;
 
     dispatch::dispatch_apply(static_cast<ptrdiff_t>(h) / stride + 1, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), [&] (size_t idx) {
-        for (auto y = idx * stride; y < std::min(static_cast<ptrdiff_t>((idx + 1) * stride), static_cast<ptrdiff_t>(h)); y++)
+        for (auto y = static_cast<ptrdiff_t>(idx * stride); y < std::min(static_cast<ptrdiff_t>((idx + 1) * stride), static_cast<ptrdiff_t>(h)); y++)
         {
             auto pri_pixels_failed = 0u;
             auto pri_error_sum = 0.;


### PR DESCRIPTION
Since GNU GCC has been removed from Mac OS X, there is no default compiler supported OpenMP on Mac OS X platform. So I rewrite the OpenMP part to take advantage of multiprocessor by libdispatch which is just a library (not a dialect so no need of special compiler support) and has a good cross-platform compatibility.