### PR TITLE
explain allowed image formats in --help string

### DIFF
--- a/compare_args.cpp
+++ b/compare_args.cpp
@@ -36,9 +36,10 @@ namespace pdiff
 
 
     static const auto USAGE =
-"Usage: perceptualdiff image1 image2\n"
+"Usage: perceptualdiff [options] image1 image2\n"
 "\n"
 "Compares image1 and image2 using a perceptually based image metric.\n"
+"Images can be in any FreeImage-supported format: TIF, PNG, etc.\n"
 "\n"
 "Options:\n"
 "  --verbose         Turn on verbose mode\n"


### PR DESCRIPTION
I made this patch to the debian package in order to refresh the debian man page `perceptualdiff(1)` using `help2man` without manual tweaking, and to keep the `--help` text consistent with the man page. And I wanted to refresh the man page because the options changed, adding hyphens and such, and tracking this manually seemed tedious and error-prone.