### PR TITLE
test script robustness and flexibility

### DIFF
--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -28,6 +28,7 @@ EOF
 readonly script_directory=$(dirname "$0")
 cd "$script_directory"
 
+if [ -z "${pdiff:=}" ]; then
 found=0
 for d in ../build .. ../obj*; do
     pdiff="$d/perceptualdiff"
@@ -40,9 +41,9 @@ done
 if [ $found = 0 ]; then
     echo 'perceptualdiff must be built and exist in the repository root or the "build" directory'
     exit 1
-else
-    echo "*** testing executable binary $pdiff"
 fi
+fi
+echo "*** testing executable binary $pdiff"
 
 #------------------------------------------------------------------------------
 

--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -24,6 +24,8 @@ FAIL alpha1.png alpha2.png
 EOF
 }
 
+echo "*** tmpdir: ${tmpdir:=/tmp}"
+
 # Change to test directory
 echo "*** script_directory: ${script_directory:=$(dirname "$0")}"
 cd "$script_directory"
@@ -78,19 +80,19 @@ fi
 "$pdiff" --help | grep -i 'usage'
 
 rm -f diff.png
-"$pdiff" --output diff.png --verbose fish{1,2}.png 2>&1 | grep -q 'FAIL'
-ls diff.png
-rm -f diff.png
+"$pdiff" --output ${tmpdir}/diff.png --verbose fish{1,2}.png 2>&1 | grep -q 'FAIL'
+ls ${tmpdir}/diff.png
+rm -f ${tmpdir}/diff.png
 
-head fish1.png > fake.png
-"$pdiff" --verbose fish1.png fake.png 2>&1 | grep -q 'Failed to load'
-rm -f fake.png
+head fish1.png > ${tmpdir}/fake.png
+"$pdiff" --verbose fish1.png ${tmpdir}/fake.png 2>&1 | grep -q 'Failed to load'
+rm -f ${tmpdir}/fake.png
 
-mkdir -p unwritable.png
-"$pdiff" --output unwritable.png --verbose fish{1,2}.png 2>&1 | grep -q 'Failed to save'
-rmdir unwritable.png
+mkdir -p ${tmpdir}/unwritable.png
+"$pdiff" --output ${tmpdir}/unwritable.png --verbose fish{1,2}.png 2>&1 | grep -q 'Failed to save'
+rmdir ${tmpdir}/unwritable.png
 
-"$pdiff" fish{1,2}.png --output foo 2>&1 | grep -q 'unknown filetype'
+"$pdiff" fish{1,2}.png --output ${tmpdir}/foo 2>&1 | grep -q 'unknown filetype'
 "$pdiff" --verbose fish1.png 2>&1 | grep -q 'Not enough'
 "$pdiff" --down-sample -3 fish1.png Aqsis_vase.png 2>&1 | grep -q 'Invalid'
 "$pdiff" --threshold -3 fish1.png Aqsis_vase.png 2>&1 | grep -q 'Invalid'

--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -77,7 +77,7 @@ fi
 "$pdiff" --help | grep -i 'usage'
 
 rm -f diff.png
-"$pdiff" --output diff.png --verbose fish[12].png 2>&1 | grep -q 'FAIL'
+"$pdiff" --output diff.png --verbose fish{1,2}.png 2>&1 | grep -q 'FAIL'
 ls diff.png
 rm -f diff.png
 
@@ -86,10 +86,10 @@ head fish1.png > fake.png
 rm -f fake.png
 
 mkdir -p unwritable.png
-"$pdiff" --output unwritable.png --verbose fish[12].png 2>&1 | grep -q 'Failed to save'
+"$pdiff" --output unwritable.png --verbose fish{1,2}.png 2>&1 | grep -q 'Failed to save'
 rmdir unwritable.png
 
-"$pdiff" fish[12].png --output foo 2>&1 | grep -q 'unknown filetype'
+"$pdiff" fish{1,2}.png --output foo 2>&1 | grep -q 'unknown filetype'
 "$pdiff" --verbose fish1.png 2>&1 | grep -q 'Not enough'
 "$pdiff" --down-sample -3 fish1.png Aqsis_vase.png 2>&1 | grep -q 'Invalid'
 "$pdiff" --threshold -3 fish1.png Aqsis_vase.png 2>&1 | grep -q 'Invalid'
@@ -97,7 +97,7 @@ rmdir unwritable.png
 "$pdiff" --verbose --scale fish1.png Aqsis_vase.png 2>&1 | grep -q 'FAIL'
 "$pdiff" --down-sample 2 fish1.png Aqsis_vase.png 2>&1 | grep -q 'FAIL'
 "$pdiff"  /dev/null /dev/null 2>&1 | grep -q 'Unknown filetype'
-"$pdiff" --verbose --sum-errors fish[12].png 2>&1 | grep -q 'sum'
+"$pdiff" --verbose --sum-errors fish{1,2}.png 2>&1 | grep -q 'sum'
 "$pdiff" --color-factor .5 -threshold 1000 --gamma 3 --luminance 90 cam_mb_ref.tif cam_mb.tif
 "$pdiff" --verbose -down-sample 30 -scale --luminance-only --fov 80 cam_mb_ref.tif cam_mb.tif
 "$pdiff" --fov wrong fish1.png fish1.png 2>&1 | grep -q 'Invalid argument'

--- a/test/run_tests.bash
+++ b/test/run_tests.bash
@@ -25,7 +25,7 @@ EOF
 }
 
 # Change to test directory
-readonly script_directory=$(dirname "$0")
+echo "*** script_directory: ${script_directory:=$(dirname "$0")}"
 cd "$script_directory"
 
 if [ -z "${pdiff:=}" ]; then


### PR DESCRIPTION
Debian and other distributions like to be able to run tests both at built time, against the built package, and at a separate test time, where they're run against an installed binary package. To simplify this, the test script here needs to allow an external argument to tell it where the executable to be tested lives, and to write files to a temp directory instead of in the source tree.

With these patches it seems to work fine both at build time and for testing an out-of-tree binary.