### PR TITLE
Fix:#22 CMake Compatibility with Version 4.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(perceptualdiff)
 
 cmake_minimum_required(VERSION 3.1...3.5)
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 project(perceptualdiff)
 
-cmake_minimum_required(VERSION 3.1)
-
+cmake_minimum_required(VERSION 3.1...3.5)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
This pull request resolves a compatibility issue with CMake 4.0.0. The original CMakeLists.txt specified cmake_minimum_required(VERSION 3.1), which is no longer supported in CMake 4.0+. As a result, configuration would fail with an error regarding outdated compatibility.

Fixes #22 .

🛠️ Changes Made
Updated cmake_minimum_required(VERSION 3.1...3.5) to VERSION 3.5 to meet the new minimum requirements introduced in CMake 4.0.0 and also able to run VERSION 3.1 to 3.5. So it will also run on older version.


Ensured that no other parts of the configuration were impacted by this version change.

🧪 Testing
Successfully ran make with CMake 4.0.0.

Verified that the project configures, builds, and installs correctly.

📦 Related
Let me know if you'd like to add a screenshot of the error, mention others, or reference additional issues/branches!

<img width="503" alt="open-1" src="https://github.com/user-attachments/assets/c82e51b3-d00d-4d04-85fd-aef595b01463" />
<img width="196" alt="open-2" src="https://github.com/user-attachments/assets/42b53437-6987-44bc-8841-fbc344534da2" />
<img width="953" alt="open-3" src="https://github.com/user-attachments/assets/24f3d7e4-2a77-442b-9128-7af89e3c8a10" />


I have edited some part because  of safety  issue. If you have any Questions  feel free to ask me.
